### PR TITLE
config item to trunc file names

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1501,8 +1501,13 @@ fn format(out: &mut Output, repo: &Repository, m: &ArgMatches) -> Result<()> {
     } else {
         Box::new(std::io::stdout())
     };
+    let file_name_size = match config.get_i32("series.truncnamesize") {
+        Ok(v) => v as usize,
+        _ => 80
+    };
+
     let patch_file = |name: &str| -> Result<Box<IoWrite>> {
-        let name = format!("{}{}", file_prefix, name);
+        let name = format!("{}{2:.*}", file_prefix, file_name_size, name);
         println!("{}", name);
         Ok(Box::new(try!(File::create(name))))
     };


### PR DESCRIPTION
Trunc file names to 80 char by default, or use config series.truncnamesize.
I'm new to rust so it may be ugly.

We had the problem when importing commit with very large commit message on the first line (file names were too long)