### PR TITLE
rebase: Add support for --exec

### DIFF
--- a/git-series.1
+++ b/git-series.1
@@ -226,7 +226,9 @@ reordering, dropping, combining, or editing commits.
 \fB-x \fIcmd\fR | \fB--exec \fIcmd\fR
 Append "exec \fIcmd\fR" after each line creating a commit in the final history.
 \fIcmd\fR will be interpreted as one or more shell commands. This option can
-only be used in conjunction with the \fB--interactive\fR option.
+only be used in conjunction with the \fB--interactive\fR option. You may
+execute several commands by giving more than one \fB--exec\fR.
+
 .RE
 
 .TP

--- a/git-series.1
+++ b/git-series.1
@@ -207,7 +207,7 @@ Moving the current series will make the destination the current series.
 You can also invoke this as \fBgit series rename\fR.
 
 .TP
-\fBgit series rebase\fR [\fB-i\fR|\fB--interactive\fR] [\fIonto\fR]
+\fBgit series rebase\fR [\fB-i\fR|\fB--interactive\fR] [\fB--exec \fIcmd\fR] [\fIonto\fR]
 Rebase the patch series, either onto a new base, interactively, or both.
 The patch series must have a base set with \fBgit series base\fR, to identify
 the series of patches to rebase.
@@ -222,6 +222,11 @@ refname~2.
 Interactively edit the list of commits.
 This uses the same format and syntax as \fBgit rebase -i\fR, to allow
 reordering, dropping, combining, or editing commits.
+.TP
+\fB-x \fIcmd\fR | \fB--exec \fIcmd\fR
+Append "exec \fIcmd\fR" after each line creating a commit in the final history.
+\fIcmd\fR will be interpreted as one or more shell commands. This option can
+only be used in conjunction with the \fB--interactive\fR option.
 .RE
 
 .TP

--- a/src/main.rs
+++ b/src/main.rs
@@ -1724,7 +1724,7 @@ fn rebase(repo: &Repository, m: &ArgMatches) -> Result<()> {
     }).collect::<Result<_>>());
 
     let interactive = m.is_present("interactive");
-    let exec_cmd = m.value_of("exec");
+    let exec_cmds = m.values_of("exec");
     let onto = match m.value_of("onto") {
         None => None,
         Some(onto) => {
@@ -1768,8 +1768,10 @@ fn rebase(repo: &Repository, m: &ArgMatches) -> Result<()> {
     let mut git_rebase_todo = try!(create.open(&git_rebase_todo_filename));
     for mut commit in commits {
         try!(writeln!(git_rebase_todo, "pick {}", try!(commit_obj_summarize(&mut commit))));
-        if let Some(cmd) = exec_cmd {
-            try!(writeln!(git_rebase_todo, "exec {}", cmd));
+        if let Some(ref cmds) = exec_cmds {
+            for cmd in cmds.clone() {
+                try!(writeln!(git_rebase_todo, "exec {}", cmd));
+            }
         }
     }
     if let Some(onto) = onto {
@@ -1997,7 +1999,7 @@ fn main() {
                     .about("Rebase the patch series")
                     .arg_from_usage("[onto] 'Commit to rebase onto'")
                     .arg_from_usage("-i, --interactive 'Interactively edit the list of commits'")
-                    .arg(Arg::from_usage("-x, --exec [cmd] 'Append \"exec <cmd>\" after each line creating a commit in the final history.'").requires("interactive"))
+                    .arg(Arg::from_usage("-x, --exec <cmd> 'Append \"exec <cmd>\" after each line creating a commit in the final history.'").multiple(true).number_of_values(1).requires("interactive"))
                     .group(ArgGroup::with_name("action").args(&["onto", "interactive"]).multiple(true).required(true)),
                 SubCommand::with_name("req")
                     .about("Generate a mail requesting a pull of the patch series")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1724,6 +1724,7 @@ fn rebase(repo: &Repository, m: &ArgMatches) -> Result<()> {
     }).collect::<Result<_>>());
 
     let interactive = m.is_present("interactive");
+    let exec_cmd = m.value_of("exec");
     let onto = match m.value_of("onto") {
         None => None,
         Some(onto) => {
@@ -1767,6 +1768,9 @@ fn rebase(repo: &Repository, m: &ArgMatches) -> Result<()> {
     let mut git_rebase_todo = try!(create.open(&git_rebase_todo_filename));
     for mut commit in commits {
         try!(writeln!(git_rebase_todo, "pick {}", try!(commit_obj_summarize(&mut commit))));
+        if let Some(cmd) = exec_cmd {
+            try!(writeln!(git_rebase_todo, "exec {}", cmd));
+        }
     }
     if let Some(onto) = onto {
         try!(writeln!(git_rebase_todo, "exec git series base {}", onto));
@@ -1993,6 +1997,7 @@ fn main() {
                     .about("Rebase the patch series")
                     .arg_from_usage("[onto] 'Commit to rebase onto'")
                     .arg_from_usage("-i, --interactive 'Interactively edit the list of commits'")
+                    .arg(Arg::from_usage("-x, --exec [cmd] 'Append \"exec <cmd>\" after each line creating a commit in the final history.'").requires("interactive"))
                     .group(ArgGroup::with_name("action").args(&["onto", "interactive"]).multiple(true).required(true)),
                 SubCommand::with_name("req")
                     .about("Generate a mail requesting a pull of the patch series")


### PR DESCRIPTION
This PR adds support for the `--exec` flag. It works the same way as the `--exec` flag in git-rebase .

```
-x cmd | --exec cmd
       Append  "exec  cmd"  after  each line creating a commit in the final
       history.  cmd will be interpreted as one  or  more  shell  commands.
       This  option  can only be used in conjunction with the --interactive
       option. You may execute several commands by  giving  more  than  one
       --exec.
```

This addresses #24.